### PR TITLE
Pick unarchive process correctly based on filename.

### DIFF
--- a/lib/geckodriver/helper.rb
+++ b/lib/geckodriver/helper.rb
@@ -35,11 +35,14 @@ module Geckodriver
     end
 
     def unpack_archive(file)
-      if platform == 'win'
+      case file
+      when /\.zip$/
         unzip(file)
-      else
+      when /\.tar\.gz$/
         io = ungzip(file)
         untar(io)
+      else
+        raise "Don't know how to unpack #{file}"
       end
     end
 


### PR DESCRIPTION
- There is a bug in the `unpack_archive` routine:
  platform is not always (ever?) exactly "win", instead
  it'll be "win32" or "win64" etc.
- Instead, pick the unarchive method based on the extension
  of the filename.

Happy to take suggestions for how to do this better.