### PR TITLE
Add frozen_string_literal comments

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 # Specify your gem's dependencies in geckodriver-helper.gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "bundler/gem_tasks"
 require 'rspec/core/rake_task'
 

--- a/geckodriver-helper.gemspec
+++ b/geckodriver-helper.gemspec
@@ -1,4 +1,6 @@
 # -*- encoding: utf-8 -*-
+# frozen_string_literal: true
+
 $:.push File.expand_path("../lib", __FILE__)
 require "geckodriver/helper/version"
 

--- a/lib/geckodriver/helper.rb
+++ b/lib/geckodriver/helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'geckodriver/helper/version'
 require 'fileutils'
 require 'rbconfig'

--- a/lib/geckodriver/helper/version.rb
+++ b/lib/geckodriver/helper/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Geckodriver
   class Helper
     VERSION = '0.23.0'


### PR DESCRIPTION
This saves a bit of memory and aids in the upgrade to Ruby 3.0.
https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/FrozenStringLiteralComment