### PR TITLE
Bump to version 0.27.0

### DIFF
--- a/lib/geckodriver/helper.rb
+++ b/lib/geckodriver/helper.rb
@@ -10,7 +10,7 @@ require 'rubygems/package'
 
 module Geckodriver
   class Helper
-    DRIVER_VERSION = "v0.24.0".freeze
+    DRIVER_VERSION = "v0.27.0".freeze
 
     def run *args
       download

--- a/lib/geckodriver/helper/version.rb
+++ b/lib/geckodriver/helper/version.rb
@@ -2,6 +2,6 @@
 
 module Geckodriver
   class Helper
-    VERSION = '0.24.0'
+    VERSION = '0.27.0'
   end
 end


### PR DESCRIPTION
With the recent upgrade to Firefox 80, [this P1 bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1588424) seems to be causing failures in some test runs. This will help resolve that failure.