### PR TITLE
Update geckodriver version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,21 @@
 Changelog
 ==========
 
+0.27.0 - 02 November 2020
+----------
+
+* Update geckodriver binary to v0.27.0
+
 0.0.4 - 09 October 2017
 ----------
 
-* Bug Fixing 
+* Bug Fixing
 
 0.0.3 - 10 November 2016
 ----------
 
 * Adding raise exception when SSL certificate is out of date
-* Removed faraday dependency 
+* Removed faraday dependency
 
 
 0.0.1 - 9 November 2016

--- a/lib/geckodriver/helper.rb
+++ b/lib/geckodriver/helper.rb
@@ -10,7 +10,7 @@ require 'rubygems/package'
 
 module Geckodriver
   class Helper
-    DRIVER_VERSION = "v0.24.0".freeze
+    DRIVER_VERSION = "v0.27.0".freeze
 
     def run *args
       download

--- a/lib/geckodriver/helper.rb
+++ b/lib/geckodriver/helper.rb
@@ -18,6 +18,7 @@ module Geckodriver
     end
 
     def download hit_network=false
+      remove_if_stale
       return if File.exists?(binary_path) && !hit_network
       url = download_url
       filename = File.basename url
@@ -55,6 +56,16 @@ module Geckodriver
     def download_url
       extension = platform.include?('win') ? 'zip' : 'tar.gz'
       "https://github.com/mozilla/geckodriver/releases/download/#{DRIVER_VERSION}/geckodriver-#{DRIVER_VERSION}-#{platform}.#{extension}"
+    end
+
+    def current_or_newer_version?
+      results = %x[ #{binary_path} --version ]
+      version = results.split("\n").first.split("\s")[1]
+      "v#{version}" == DRIVER_VERSION
+    end
+
+    def remove_if_stale
+      File.delete(binary_path) unless current_or_newer_version?
     end
 
     def binary_path

--- a/lib/geckodriver/helper/version.rb
+++ b/lib/geckodriver/helper/version.rb
@@ -2,6 +2,6 @@
 
 module Geckodriver
   class Helper
-    VERSION = '0.24.0'
+    VERSION = '0.27.0'
   end
 end


### PR DESCRIPTION
This updates the `geckodriver` version to the latest. 

I've also added a small function to automatically clean up stale versions of `geckodriver` automatically. This simplifies using this with RSpec.